### PR TITLE
Implement library changes to allow composing the expected user-agent string

### DIFF
--- a/src-dev/Tests/Unit/GatherContentClientTest.php
+++ b/src-dev/Tests/Unit/GatherContentClientTest.php
@@ -19,6 +19,17 @@ use GuzzleHttp\Psr7\Response;
  */
 class GatherContentClientTest extends GcBaseTestCase
 {
+    public function testVersionString()
+    {
+        $client = new Client();
+        $gc = new GatherContentClient($client);
+        $gc->setOptions([
+            'frameworkName' => 'Drupal',
+            'frameworkVersion' => '8.3.4',
+        ]);
+        static::assertEquals('Integration-Drupal-8.3.4/1.0', $gc->getVersionString());
+    }
+
     public function testGetSetEmail()
     {
         $client = new Client();

--- a/src/GatherContentClient.php
+++ b/src/GatherContentClient.php
@@ -124,6 +124,14 @@ class GatherContentClient implements GatherContentClientInterface
                 case 'apiKey':
                     $this->setApiKey($value);
                     break;
+
+                case 'frameworkVersion':
+                    $this->setFrameworkVersion($value);
+                    break;
+
+                case 'frameworkName':
+                    $this->setFrameworkName($value);
+                    break;
             }
         }
 
@@ -485,7 +493,62 @@ class GatherContentClient implements GatherContentClientInterface
     {
         return $base + [
             'Accept' => 'application/vnd.gathercontent.v0.5+json',
+            'User-Agent' => $this->getVersionString(),
         ];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getFrameworkName()
+    {
+        return $this->framework['name'];
+    }
+
+    protected $framework = ['name' => 'PHP', 'version' => 'UKNOWN'];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setFrameworkName($value)
+    {
+        $this->framework['name'] = $value;
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getFrameworkVersion()
+    {
+        return $this->framework['version'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setFrameworkVersion($version)
+    {
+        $this->framework['version'] = $version;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIntegrationVersion()
+    {
+        return static::INTEGRATION_VERSION;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getVersionString()
+    {
+        $frameworkName = $this->getFrameworkName();
+        $frameworkVersion = $this->getFrameworkVersion();
+        $integrationVersion = $this->getIntegrationVersion();
+        return sprintf('Integration-%s-%s/%s', $frameworkName, $frameworkVersion, $integrationVersion);
     }
 
     /**

--- a/src/GatherContentClientInterface.php
+++ b/src/GatherContentClientInterface.php
@@ -17,6 +17,8 @@ interface GatherContentClientInterface
 
     const PROJECT_TYPE_OTHER = 'other';
 
+    const INTEGRATION_VERSION = '1.0';
+
     public function getResponse();
 
     public function getEmail();
@@ -39,6 +41,36 @@ interface GatherContentClientInterface
      * @return $this
      */
     public function setBaseUri($value);
+
+    /**
+     * @return string[]
+     */
+    public function getIntegrationVersion();
+
+    /**
+     * @return $this
+     */
+    public function setFrameworkVersion($value);
+
+    /**
+     * @return string[]
+     */
+    public function getFrameworkVersion();
+
+    /**
+     * @return $this
+     */
+    public function setFrameworkName($value);
+
+    /**
+     * @return string[]
+     */
+    public function getFrameworkName();
+
+    /**
+     * @return string[]
+     */
+    public function getVersionString();
 
     /**
      * GatherContentClientInterface constructor.


### PR DESCRIPTION
As per #11 requires, the following changes allow the library to pass along both a version string related to the library itself, and allow the implementing framework component to pass another version id along (representing the framework version) to Gather Content.