### PR TITLE
Add repeatable property to text element to support repeatable settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-
 /bin/
 /reports/
 /vendor/
+
+.phpunit.result.cache

--- a/src/DataTypes/ElementTextMeta.php
+++ b/src/DataTypes/ElementTextMeta.php
@@ -15,6 +15,11 @@ class ElementTextMeta extends Base
     public $validation = [];
 
     /**
+     * @var array
+     */
+    public $repeatable = [];
+
+    /**
      * {@inheritdoc}
      */
     protected $unusedProperties = ['id'];
@@ -30,6 +35,7 @@ class ElementTextMeta extends Base
             [
                 'is_plain' => 'isPlain',
                 'validation' => 'validation',
+                'repeatable' => 'repeatable',
             ]
         );
 

--- a/src/DataTypes/Item.php
+++ b/src/DataTypes/Item.php
@@ -159,9 +159,16 @@ class Item extends Base
         $elements = [];
 
         foreach ($elementData as $element) {
+            if (empty($element)) {
+                continue;
+            }
             $class = ElementSimpleChoice::class;
             if (isset($element['file_id'])) {
                 $class = ElementSimpleFile::class;
+            }
+            if (!is_array($element)) {
+                $class = ElementSimpleText::class;
+                $element = ['value' => $element];
             }
             /** @var \Cheppers\GatherContent\DataTypes\ElementBase[] $elements */
             $elements[] = new $class($element);


### PR DESCRIPTION
A new _repeatable_ property has been added to text element to support GatherContent's new repeatable text field feature.