### PR TITLE
Add alt_text property to ElementSimpleFile

### DIFF
--- a/src/DataTypes/ElementSimpleFile.php
+++ b/src/DataTypes/ElementSimpleFile.php
@@ -42,6 +42,11 @@ class ElementSimpleFile extends ElementBase
     public $size = null;
 
     /**
+     * @var string
+     */
+    public $altText = '';
+
+    /**
      * {@inheritdoc}
      */
     protected function initPropertyMapping()
@@ -56,6 +61,7 @@ class ElementSimpleFile extends ElementBase
                 'url' => 'url',
                 'optimised_image_url' => 'optimisedImageUrl',
                 'size' => 'size',
+                'alt_text' => 'altText',
             ]
         );
 


### PR DESCRIPTION
A new alt text property has been added to ElementSimpleFile to support GatherContent's image alternative text management.